### PR TITLE
Added reference to type declarations in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.0",
   "description": "gulp plugin to format source code with prettier",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "repository": "https://github.com/GAumala/gulp-prettier-plugin",
   "author": "Gabriel Aumala",
   "license": "MIT",
@@ -36,12 +37,12 @@
     "prettier": "^1.x"
   },
   "dependencies": {
+    "@types/plugin-error": "^0.1.0",
+    "@types/node": "^8.0.9",
     "plugin-error": "^0.1.2",
     "safe-buffer": "^5.1.1"
   },
   "devDependencies": {
-    "@types/node": "^8.0.9",
-    "@types/plugin-error": "^0.1.0",
     "babel-preset-es2015": "^6.24.1",
     "coveralls": "^2.13.1",
     "gulp": "^3.9.1",


### PR DESCRIPTION
No reason not to reference the generated type declarations in the distribution. This adds the necessary config to `package.json` and moves the `@types/*` devDependencies to dependencies, as they should be known too.